### PR TITLE
impr: load-state concurrency

### DIFF
--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -2,7 +2,7 @@ import { Subject } from 'rxjs'
 import { config } from './config'
 import { db } from './database'
 import { logger } from './lib/logger'
-import { ChainGraphMappings } from './types'
+import type { ChainGraphMappings } from './types'
 
 export interface MappingsReader {
   mappings$: Subject<ChainGraphMappings[]>
@@ -14,7 +14,7 @@ export const createMappingsReader = async (): Promise<MappingsReader> => {
   const mappings$ = new Subject<ChainGraphMappings[]>()
 
   logger.info('Subscribing to contract mappings, refreshing every 1s ...')
-  setInterval(async () => {
+  const interval = setInterval(async () => {
     try {
       const result: ChainGraphMappings[] = await db.query(
         'SELECT * FROM mappings WHERE chain = $1',
@@ -26,7 +26,7 @@ export const createMappingsReader = async (): Promise<MappingsReader> => {
         mappings$.next(mappings)
         logger.info('New mappings', JSON.stringify(mappings))
       }
-
+      clearInterval(interval)
     } catch (error) {
       logger.error('Error updating contract mappings', error)
     }
@@ -34,6 +34,6 @@ export const createMappingsReader = async (): Promise<MappingsReader> => {
 
   // resolve promise only after data has been loaded
   return new Promise((resolve) =>
-    mappings$.subscribe(() => resolve({ mappings, mappings$ }))
+    mappings$.subscribe(() => resolve({ mappings, mappings$ })),
   )
 }


### PR DESCRIPTION
# Changelog:

- Load state throttling to avoid concurrencie issues with either the indexer or RPC.
- Clearing the mapping interval after getting the mappings.

> Adding these changes due these was found at the remote instance. I think that for precaution, we can add this throttling and clearing the interval whenevert is no longer required to do. Unless the interval was intended to get the mappings live and so we can get the actions/table_rows as real-time?